### PR TITLE
Quality of life updates

### DIFF
--- a/Problems/P.000003
+++ b/Problems/P.000003
@@ -5,7 +5,7 @@ What is the combinatorial complexity of the Voronoi diagram
 of a set of lines (or line segments) in three dimensions?
 * Origin: Uncertain, pending investigation.
 * Status/Conjectures: Open.
-Conjectured to be nearly quadradic.
+Conjectured to be nearly quadratic.
 * Partial and Related Results:
 There is a gap between
 a lower bound of $\Omega(n^2)$ and an upper bound that is

--- a/Problems/P.000009
+++ b/Problems/P.000009
@@ -6,7 +6,7 @@ flat to a single, nonoverlapping, simple polygon?
 * Origin: First stated in~\cite{s-cpcn-75}, but in
 spirit at least goes back to Albrecht D\"urer~\cite{d-pm-1525}.
 * Status/Conjectures: Open.
-It seems to be a widespead hunch that the answer is {\sc yes}.
+It seems to be a widespread hunch that the answer is {\sc yes}.
 * Partial and Related Results:
 The answer is known to be {\sc no}
 for nonconvex polyhedra even with triangular faces~\cite{bdekms-upcf-03},

--- a/Problems/P.000027
+++ b/Problems/P.000027
@@ -24,7 +24,7 @@ edges.
 In a sense, these hexahedra are intermediate between the 
 topological and geometric meshes mentioned above.
 The faces are not necessarily planar, but this is not a
-crucial aspect in applications, such a fluid dynamics simulations.
+crucial aspect in applications, such as fluid dynamics simulations.
 
 The question of whether a hexahedral mesh with planar faces
 exists remains open.

--- a/Problems/P.000031
+++ b/Problems/P.000031
@@ -24,9 +24,9 @@ even a single \emph{nonperiodic} ray, i.e.,
 one that reflects forever (so is trapped)
 but never rejoins its earlier path---was disproved by
 Ben Stephens in 2002, who designed
-a contruction of 8 mirrors that traps a ray reflecting 
+a construction of 8 mirrors that traps a ray reflecting 
 nonperiodically.
-A similar construction was discovered and described in~\cite{msz-tlram-09},
+A similar construction was discovered and described in~\cite{msz-tlram-12},
 which also established that any finite number of rays can be trapped
 nonperiodically.
 Milovich~\cite{m-tlm-04} proved that if the angles between the lines

--- a/Problems/P.000036
+++ b/Problems/P.000036
@@ -5,7 +5,7 @@ How much extra space is required to compute the convex hull of a simple
 polygonal chain or simple polygon in linear time?
 
 More precisely, given the $n$ points in order along the chain in an array $A$,
-the alogorithm must re-arrange the points inplace in the array and output a
+the algorithm must re-arrange the points inplace in the array and output a
 number $h$ so that the first $h$ elements in the resulting array are the points
 on the convex hull in order.  The goal is to minimize the extra storage past
 the array $A$, say to $O(\log n)$ or ideally $O(1)$.
@@ -15,7 +15,7 @@ the array $A$, say to $O(\log n)$ or ideally $O(1)$.
 From the abstract of \cite{bc-sacch-04}:
 ``we present a simple self-contained solution that uses $O(\log n)$ space, and indicate how to improve it to $O(1)$ space with the same techniques used for stable partition.''
 %For computing the convex hull of a set of points,
-%Br{\"o}nnimann et al. \cite{bikmm-oipcha-01} gave inplace alogorithms using
+%Br{\"o}nnimann et al. \cite{bikmm-oipcha-01} gave inplace algorithms using
 %$O(1)$ extra space with running time $O(n \log h)$ for $h$ points on the
 %convex hull, and running time $O(n)$ if the points have been presorted
 %according to one coordinate.

--- a/Problems/P.000049
+++ b/Problems/P.000049
@@ -35,7 +35,7 @@ such that the Euclidean length of the shortest edge is maximized?
 Stated in~\cite{acmsy-mst-97}, shown NP-hard in dimensions $d\geq 3$
 in~\cite{f-shmtspgd-99}, open for $d=2$.
 Also, no bounds on approximation are known in a geometric context;
-the best known aproximation algorithm from \cite{acmsy-mst-97}
+the best known approximation algorithm from \cite{acmsy-mst-97}
 achieves an approximation factor of 2, but does not use geometry.
 
 * Reward: <none>

--- a/Problems/P.000063
+++ b/Problems/P.000063
@@ -20,16 +20,16 @@ subject to insertion, deletion, and predecessor and successor queries
 * Partial and Related Results:
 For 14 years, the authority on this problem was Agarwal and Matou\v{s}ek's
 FOCS'92 paper \cite{am-dhsrr-95} which describes two data structures:
-one suports updates in $O(n^\epsilon)$ amortized time and
+one supports updates in $O(n^\epsilon)$ amortized time and
 queries in $O(\log n)$ worst-case time,
-while the other suports updates in $O(\log^2 n)$ amortized time
+while the other supports updates in $O(\log^2 n)$ amortized time
 queries in $O(n^\epsilon)$ worst-case time,
 for any $\epsilon > 0$.
 The nearest-neighbor problem is a decomposable search problem,
 so when deletions are forbidden, the general techniques of Bentley and Saxe
 \cite{bs-dsp1s-80} yield an $O(\log^2 n)$ amortized bound for updates
 and queries.
-In 2006, Chan \cite{c-dds3c-06} obtained the first polylogarithimc data
+In 2006, Chan \cite{c-dds3c-06} obtained the first polylogarithmic data
 structure for 3D convex hulls and therefore 2D nearest neighbors.
 His data structure supports insertions in $O(\log^3 n)$ expected
 amortized time, deletions in $O(\log^6 n)$ expected amortized time,

--- a/Problems/P.000069
+++ b/Problems/P.000069
@@ -2,7 +2,7 @@
 * Problem: Isoceles Planar Graph Drawing
 * Statement:
 Given a planar graph that is interior triangulated (all
-interior faces are triangles), is there a staight-line
+interior faces are triangles), is there a straight-line
 drawing of the graph such that each face is an isoceles
 triangle (i.e., it has two equal-length sides)?
 

--- a/topp.bib
+++ b/topp.bib
@@ -153,11 +153,10 @@
 , author =	"Oswin Aichholzer and Franz Aurenhammer and Ferran Hurtado and Hannes Krasser"
 , title =	"Towards compatible triangulations"
 , journal =	"Theoret. Comput. Sci."
-, volume =	"??"
+, volume =	296
 , year =	2002
-, pages =	"??--??"
-, note =	"\url{http://www.cis.TUGraz.at/igi/oaich/}"
-, url =	"http://www.cis.TUGraz.at/igi/oaich/publications.html"
+, pages =	"3--13"
+, url =	"https://www.sciencedirect.com/science/article/pii/S0304397502004280?via%3Dihub"
 , succeeds =	"aak-ctps-01"
 , update =	"02.03 orourke"
 }
@@ -252,8 +251,8 @@
 , title =	"Heuristics for the Generation of Random Polygons"
 , booktitle =	"Proc. 8th Canad. Conf. Comput. Geom."
 , year =	1996
-, pages =	"38--43"
-, url =	"http://www.cosy.sbg.ac.at/~held/papers/cccg96.ps.gz"
+, pages =	"38--43"  
+, url =	"https://www.cccg.ca/proceedings/1996/cccg1996_0007.pdf"
 , update =	"98.11 bibrelex, 98.03 mitchell, 97.03 agarwal, 96.09 held+mitchell"
 }
 
@@ -1614,7 +1613,7 @@ Convex Partitions"
 , title = "Geometric Folding Algorithms: Linkages, Origami, Polyhedra"
 , publisher = "Cambridge University Press"
 , note = "In press.
-        \url{http://www.gfalop.org} (formerly \url{http://www.fucg.org})."
+        \url{https://gfalop.org/} (formerly \url{http://www.fucg.org})."
 , year = 2007
 }
 
@@ -1622,7 +1621,7 @@ Convex Partitions"
 , author = "Erik D.~Demaine and Joseph O'Rourke"
 , title = "Geometric Folding Algorithms: Linkages, Origami, Polyhedra"
 , publisher = "Cambridge University Press"
-, note = "\url{http://www.gfalop.org}."
+, note = "\url{https://gfalop.org/}."
 , month = jul
 , year = 2007
 }
@@ -1933,12 +1932,17 @@ Perouz Taslakian"
 , pages =	"153--180"
 }
 
-@unpublished{msz-tlram-09
-, author =	"Zachary Mitchell and Gregory Simon and Xueying Zhao"
-, title =	"Trapping light rays aperiodically with mirrors"
-, year =	2009
-, month =	aug
-, note =	"Unpublished manuscript"
+@article{msz-tlram-12
+, author   = "Zachary Mitchell and Gregory Simon and Xueying Zhao"
+, title    = "Trapping light rays aperiodically with mirrors"
+, journal  = "Involve, A Journal of Mathematics"
+, volume   = 5
+, number   = 1
+, year     = 2012
+, pages    = "9--14"
+, doi      = "10.2140/involve.2012.5.9"
+, url      = "https://msp.org/involve/2012/5-1/involve-v5-n1-p02-s.pdf"
+, keywords = "trapping light, mirrors, billiards, aperiodicity, dynamical systems"
 }
 
 @unpublished{bddossw-pi2ay-10
@@ -2239,7 +2243,7 @@ Stefanie Wurher"
 , title =       "Polyominoes and Other Animals"
 , booktitle =   "The Geometry Junkyard"
 , note =
-"\url{http://www1.ics.uci.edu/~eppstein/junkyard/polyomino.html}"
+"\url{https://ics.uci.edu/~eppstein/junkyard/polyomino.html}"
 , update =      "01.11 demaine"
 }
 
@@ -2641,7 +2645,7 @@ em under geometric distances"
 , location =	"Providence"
 , year =	2004
 , pages =	"55--66"
-, url =		 "http://www.scs.carleton.ca/~davidw/papers/DujWoo-GD03.pdf"
+, url =		 "https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=3c153164b26a61d80db9ac76b033a5ed7468a346"
 }
 
 @inproceedings{w-qltw-02
@@ -2656,7 +2660,7 @@ em under geometric distances"
 , publisher =	 "Springer"
 , volume =	 "2556"
 , editor =	 "Manindra Agrawal and Anil Seth"
-, url =		 "http://www.scs.carleton.ca/~davidw/papers/Wood-FSTTCS02.pdf"
+, url =		 "https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=c5aef31c4cfc507e253b1f9bf1d561a55f5562cb"
 }
 
 @inproceedings{dw-tpkt-03
@@ -2669,7 +2673,7 @@ em under geometric distances"
 , booktitle =	 "Proc. 29th Workshop on Graph Theoretic Concepts in
                   Computer Science (WG'03)"
 , editor =	 "Hans Bodlaender"
-, url =		 "http://www.scs.carleton.ca/~davidw/papers/DujWoo-WG03.pdf"
+, url =		 "https://cglab.ca/~vida/pubs/papers/DujWoo-WG03.pdf"
 , pages =	"205--217"
 , year =	"2003"
 }
@@ -2681,7 +2685,7 @@ em under geometric distances"
 , number =	 "TR-2003-07"
 , institution =	 "School of Computer Science, Carleton University"
 , address =	 "Ottawa, Canada"
-, url =		 "http://www.scs.carleton.ca/~davidw/papers/DujWoo-Subdivisions-TechReport.pdf"
+, url =		 "https://dmtcs.episciences.org/346/pdf"
 }
 
 @article{ck-lbsus-89
@@ -2723,7 +2727,7 @@ em under geometric distances"
 , booktitle = "Abstracts 20th European Workshop Comput. Geom."
 , site = "Seville, Spain"
 , year = 2004
-, url = "http://www.us.es/ewcg04/Articulos/krasser.ps"
+, url = "https://www.sciencedirect.com/science/article/pii/S0925772107000958"
 }
 
 @article{d-eaplp-87
@@ -2779,8 +2783,8 @@ em under geometric distances"
 , journal =     "Algorithmica"
 , volume =      30
 , year =        2001
-, pages =       "450--470"
-, url =         "http://www.zaik.uni-koeln.de/~paper/preprints.html?show=zpr97-296"
+, pages =       "451--470"
+, url =         "https://www.ibr.cs.tu-bs.de/users/fekete/hp/publications/PDF/2001-Approximation_of_Geometric_Dispersion_Problems.pdf"
 }
 
 @techreport{ms-gicsb-00

--- a/topp.bib
+++ b/topp.bib
@@ -1608,15 +1608,6 @@ Convex Partitions"
 , pages =       "165--177"
 }
 
-@book{do-fucg-06
-, author = "Erik D.~Demaine and Joseph O'Rourke"
-, title = "Geometric Folding Algorithms: Linkages, Origami, Polyhedra"
-, publisher = "Cambridge University Press"
-, note = "In press.
-        \url{https://gfalop.org/} (formerly \url{http://www.fucg.org})."
-, year = 2007
-}
-
 @book{do-gfalop-07
 , author = "Erik D.~Demaine and Joseph O'Rourke"
 , title = "Geometric Folding Algorithms: Linkages, Origami, Polyhedra"
@@ -2645,7 +2636,7 @@ em under geometric distances"
 , location =	"Providence"
 , year =	2004
 , pages =	"55--66"
-, url =		 "https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=01c76d51dcff3d1d499fcd24ba65e9e87aaaecab"
+, url =		 "https://doi.org/10.1007/978-3-540-24595-7_18"
 }
 
 @inproceedings{w-qltw-02
@@ -2660,7 +2651,7 @@ em under geometric distances"
 , publisher =	 "Springer"
 , volume =	 "2556"
 , editor =	 "Manindra Agrawal and Anil Seth"
-, url =		 "https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=c5aef31c4cfc507e253b1f9bf1d561a55f5562cb"
+, url =		 "https://doi.org/10.1007/3-540-36206-1_31"
 }
 
 @inproceedings{dw-tpkt-03

--- a/topp.bib
+++ b/topp.bib
@@ -156,7 +156,7 @@
 , volume =	296
 , year =	2002
 , pages =	"3--13"
-, url =	"https://www.sciencedirect.com/science/article/pii/S0304397502004280?via%3Dihub"
+, url =	"https://doi.org/10.1016/S0304-3975(02)00428-0"
 , succeeds =	"aak-ctps-01"
 , update =	"02.03 orourke"
 }
@@ -2645,7 +2645,7 @@ em under geometric distances"
 , location =	"Providence"
 , year =	2004
 , pages =	"55--66"
-, url =		 "https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=3c153164b26a61d80db9ac76b033a5ed7468a346"
+, url =		 "https://citeseerx.ist.psu.edu/document?repid=rep1&type=pdf&doi=01c76d51dcff3d1d499fcd24ba65e9e87aaaecab"
 }
 
 @inproceedings{w-qltw-02
@@ -2727,7 +2727,7 @@ em under geometric distances"
 , booktitle = "Abstracts 20th European Workshop Comput. Geom."
 , site = "Seville, Spain"
 , year = 2004
-, url = "https://www.sciencedirect.com/science/article/pii/S0925772107000958"
+, url = "https://doi.org/10.1016/j.comgeo.2007.07.006"
 }
 
 @article{d-eaplp-87
@@ -2821,7 +2821,7 @@ em under geometric distances"
 , pages =       {162--171}
 , volume =      2976
 , series =      {Lecture Notes in Computer Science}
-, url =		{http://springerlink.metapress.com/openurl.asp?genre=article&issn=0302-9743&volume=2976&spage=162}
+, url =		{https://doi.org/10.1016/j.comgeo.2005.11.005}
 }
 
 @misc{val
@@ -2835,7 +2835,7 @@ em under geometric distances"
 , author =      "Randall Dougherty and Vance Faber and Michael Murphy"
 , title =       "Unflippable Tetrahedral Complexes"
 , journal =     "Discrete Comput. Geom."
-, url =         "http://springerlink.metapress.com/openurl.asp?genre=article&id=doi:10.1007/s00454-004-1097-3"
+, url =         "https://doi.org/10.1007/s00454-004-1097-3"
 , volume =	32
 , pages =	"309--315"
 , year = 	2004


### PR DESCRIPTION
- Update bib entry msz-tlram-09 with the published version (now msz-tlram-12)
- Fix spelling errors in problems 3, 9, 27, 31, 36, 49, 63, 69
- Update deprecated bib urls for entries aahk-tct-02, ah-hgrp-96, do-fucg-06, do-gfalop-07, e-gj-poa, dw-tdgd-03, w-qltw-02, dw-tpkt-03, dw-nrgl-03, ahk-twpst-04, bf-agdp-01, bc-sacch-04, dfm-utc-04