### PR TITLE
Update remainder of deprecated urls

### DIFF
--- a/Problems/P.000033
+++ b/Problems/P.000033
@@ -62,7 +62,7 @@ which improves on the above bound $O(2^{2k\lg n})$
 whenever $n \le c k \lg k$ for some $c$.
 
 At the other extreme,
-Qian and Wang \cite{qw-nubdb-04,qw-nubdb-05} show an upper bound on $r(n,k)$
+Qian and Wang \cite{qw-nubdb-05} show an upper bound on $r(n,k)$
 of $O(n^{-2k+\frac{3}{2}})$.
 %Marc Glisse corrects that it is NOT tight for k=2.
 %, and show that this is tight

--- a/topp.bib
+++ b/topp.bib
@@ -327,7 +327,7 @@
 , year =	1998
 , pages =	"70--71"
 , note =	"Full version in {\em Elec. Proc.}:
-		\url{http://cgm.cs.mcgill.ca/cccg98/proceedings/cccg98-biedl-unfolding.ps.gz}"
+		\url{https://erikdemaine.org/papers/CCCG98b/paper.ps}"
 , update =	"00.03 orourke"
 }
 
@@ -398,8 +398,8 @@
 , title =	"Optimal In-Place Planar Convex Hull Algorithms"
 , howpublished =	"11th Annu. Fall Workshop Comput. Geom."
 , year =	2001
-, note =	"\url{http://geometry.poly.edu/cgwpapers/}"
-, url =	"http://geometry.poly.edu/cgwpapers/hbr\_inplace.ps"
+, note =	"\url{https://web.archive.org/web/20030719100100/http://geometry.poly.edu/cgwpapers/}"
+, url =	"https://web.archive.org/web/20030725014511/http://geometry.poly.edu/cgwpapers/hbr_inplace.ps"
 , update =	"02.03 orourke"
 }
 
@@ -514,7 +514,7 @@
 , booktitle =	"ISAAC: 9th Internat. Sympos. Algorithms Computation"
 , year =	1998
 , pages =	"367--376"
-, url =	"citeseer.nj.nec.com/cheng98quadtree.html"
+, url =	"https://doi.org/10.1007/3-540-49381-6_39"
 , update =	"01.07 orourke"
 }
 
@@ -1907,11 +1907,12 @@ Perouz Taslakian"
 }
 
 @unpublished{h-astlc-09
-, author =	"Sariel Har-Peled"
-, title =	"Approximating Spanning Trees with Low Crossing Numbers"
-, month =	jun
-, year =	2009
-, note =	"\url{http://valis.cs.uiuc.edu/~sariel/papers/09/crossing/}"
+, author = "Sariel Har-Peled"
+, title  = "Approximating Spanning Trees with Low Crossing Numbers"
+, month  = jun
+, year   = 2009
+, note   = "arXiv:0907.1131 [cs.CG]"
+, url    = "https://arxiv.org/abs/0907.1131"
 }
 
 @article{m-tlm-04
@@ -2173,18 +2174,6 @@ Stefanie Wurher"
 , comment =	"Cao An Wang <wang@cs.mun.ca>"
 , note =	"Also Technical Report, Memorial University of Newfoundland, Oct.~2005"
 , url =         "http://dx.doi.org/10.1016/j.ipl.2006.05.002"
-}
-
-%, url =		"http://www.cs.mun.ca/~jianbo/upperbound.ps"
-%removed in favor of local link
-@techreport{qw-nubdb-04
-, author =	"Jianbo Qian and Cao An Wang"
-, title =	"New Upper Bound on Difference Between Two Sums of Square Roots of Integers"
-, institution =	"Memorial University of Newfoundland"
-, url =		"http://cs.smith.edu/~orourke/TOPP/jianbo-qian-boundRoot.ps"
-, comment =	"Jianbo Qian <jianbo@cs.mun.ca>"
-, month =	oct
-, year =	2004
 }
 
 @article{j-elat-01
@@ -2787,7 +2776,7 @@ em under geometric distances"
 , number =      {MPI-I-2000-1-004}
 , month =       {November}
 , year =        {2000}
-, url =         {http://domino.mpi-sb.mpg.de/internet/reports.nsf/NumberView/2000-1-004}
+, url =         {https://www.mpi-inf.mpg.de/~mehlhorn/ftp/improved-sepbound.ps}
 , issn =        {0946-011X}
 }
 
@@ -2796,7 +2785,7 @@ em under geometric distances"
 , title =	"How close can $\sqrt{a}+\sqrt{b}$ be to an integer?"
 , institution =	"Yale University"
 , number =	"YALEU/DCS/TR-1279"
-, url =		"ftp://ftp.cs.yale.edu/pub/TR/tr1279.pdf"
+, url =		"https://www.cs.yale.edu/publications/techreports/tr1279.pdf"
 , comment =	"Dana Angluin <angluin@cs.yale.edu>"
 , month =	mar
 , year =	2004
@@ -2883,7 +2872,7 @@ em under geometric distances"
 , month =       nov
 , year =        1971
 , pages =       {1000--1002}
-, url =         "http://links.jstor.org/sici?sici=0002-9890(197111)78\%3A9\%3C1000\%3AHMMCAT\%3E2.0.CO\%3B2-G"
+, url =         "https://doi.org/10.1080/00029890.1971.11992925"
 }
 
 @article{cs-te6op-93


### PR DESCRIPTION
- Update deprecated bib urls for bddloorw-uscop-98, bikmm-oipcha-01, cl-qrsam-98, h-astlc-09, qw-nubdb-04, ms-gicsb-00, ae-hc-04, m-hmmct-71
 - Notes:
    - Entry qw-nubdb-04 (04) became entry qw-nubdb-05 (05) after publishing. However, the original url for 04 redirected the user to another url hosting 05 according to the [Wayback Machine](https://web.archive.org/web/20060701000000*/http://cs.smith.edu/~orourke/TOPP/jianbo-qian-boundRoot.ps) in Sep. 2006. Unless the original 04 preprint can be located, I’ve removed the 04 bib entry. Also, 04 and 05 are cited inline side-by-side in Problem 33, so the problem now only cites 05.
    - I could only find the original paper for entry bikmm-oipcha-01 through the Wayback Machine along with the conference website in the note of the bib entry. The journal version published later is [here](https://doi.org/10.1007/3-540-45995-2_43) if it is preferable to create a new bib entry and use it over the Wayback archives.